### PR TITLE
Sorting-tests

### DIFF
--- a/examples/eww.yuck
+++ b/examples/eww.yuck
@@ -1,4 +1,4 @@
-(deflisten wlr_apps :initial "[]" "$PATH_TO_YOUR_PROGRAM/wlr-apps --follow")
+(deflisten wlr_apps :initial "[]" "$PATH_TO_YOUR_PROGRAM/wlr-apps -mj")
 
 (defwindow bar []
     :monitor "0"
@@ -40,18 +40,9 @@
                 :class "app_item ${app.active == true ? "active" : ""}" 
                 ;; Functionality to focus app on click, to be expanded.
                 :onclick "wlr-apps -x \"f ${app.id}\""
-                ;; Box that holds the css for displaying the icon, it uses built in gtk css from eww.
-                ;; Some apps might not display the icon.
-                ;; You can read more in https://docs.gtk.org/gtk3/css-overview.html.
-                (box :orientation "h" :class "app_image" :css ".app_image {
-                    background-image: -gtk-icontheme('${app.app_id}');
-                    background-repeat: no-repeat;
-                    background-size: cover;
-                    background-position: center;
-                    min-height: 0rem;
-                    min-width: 2rem;
-                    border-radius: 100%;
-                    }"
+                ;; This box holds the icons using the built in image functionality from eww.
+                ;; This is better than -gtk-icontheme since image actually returns a placeholder when no icon is found.
+                (box :orientation "h" :class "app_image" :css (image :icon "${app.app_id}" :icon-size "dnd")
                 )
             )
         )

--- a/src/wlr-apps.c
+++ b/src/wlr-apps.c
@@ -342,6 +342,22 @@ static void copy_state(struct toplevel_state *current,
   }
 
   if (pending->app_id) {
+    /*
+    This implementation is kinda dumb but it's the best I could come up with. Basically the -gtk-icontheme doesn't match upper and lowercase, meaning that
+    if your app_id is, for example, "org.xfce.Thunar" but the icon is found under "org.xfce.thunar" it will return null and empty icon. So we need to convert it to
+    lowercase first in order for gtk to return a valid icon. HOWEVER, the same thing occurs the other way arround, for example, "org.gnome.Calculator" only matches with the
+    uppercase, so if we convert ALL app_ids to lowercase this one won't match. From testing I think only gnome has the icon with upper case rather than lowecase.
+    To make things worse this seems to only happen with "org.something.something" app_ids, any other app in my testing matches correctly regardless of upper or lowercase.
+    I couldn't look deeper into how gtk handles this but could be a bug.
+    */
+    char gnome[] = "gnome";
+    char *res = strstr(pending->app_id, gnome);
+    // If the app_id doesn't contain "gnome" we convert everything to lowercase. if it does we leave it as it is.
+    if (res == NULL) {
+      for (int i = 0; i < strlen(pending->app_id); i++){
+        pending->app_id[i] = tolower(pending->app_id[i]);
+      }
+    }
     current->app_id = pending->app_id;
     pending->app_id = NULL;
   }


### PR DESCRIPTION
Improved the eww example to be easier to understand and now it uses the image functionality from eww which avoids icons being empty since it automatically returns a placeholder image if one is not found.

Also updated the functionality of app_id for it to make lowercase all app_id's and improve the chances of an icon actually matching since it seems that gtk doesn't match upper case with lower case and viceversa, most apps I tested seem to have a lowercase icon name but the app_id returns uppercase for some reason. The only odd fellow was gnome apps that actually have upper case icon names so I added a check to skip those from being lowercase.
